### PR TITLE
Fix Sankey plugin requiring global "width" variable

### DIFF
--- a/sankey/sankey.js
+++ b/sankey/sankey.js
@@ -127,7 +127,7 @@ d3.sankey = function() {
 
     //
     moveSinksRight(x);
-    scaleNodeBreadths((width - nodeWidth) / (x - 1));
+    scaleNodeBreadths((size[0] - nodeWidth) / (x - 1));
   }
 
   function moveSourcesRight() {


### PR DESCRIPTION
Hi,

I think there's a small bug in the Sankey plugin:

When computing the node breadths, it looks for the width of the graph in the variable `width`. That variable isn't declared anywhere in the plugin, so, for it to work, it must exist globally. Instead, you probably want to get the width from the internal variable `size`, which already holds the dimensions of the chart.

(This doesn't break in [the example](http://bost.ocks.org/mike/sankey/), because it declares the variable `width` at the top level (line 71), and the Sankey plugin therefore has access to it.)
