### PR TITLE
New options for Sankey plugin

### DIFF
--- a/sankey/README.md
+++ b/sankey/README.md
@@ -9,6 +9,9 @@ var sankey = d3.sankey()
     .nodePadding(10)
     .nodes(energy.nodes)
     .links(energy.links)
+    .overlapLinksAtSources(false)
+    .overlapLinksAtTargets(false)
+    .minValue(1)
     .layout(32);
 ```
 


### PR DESCRIPTION
I wanted a Sankey diagram where the links overlaps at the sources.  The idea I'm trying to capture is that a source node can have some output, and that same output can be used (or read) by multiple target nodes.  This patch creates options for whether the links will overlap at their sources or targets.

I also wanted a minimum value for my Sankey nodes and links, so that if I don't know a particular node's value at the beginning, I can still display it with some minimum value and then update it with its actual value later.
