### PR TITLE
Adding basic JSONP plugin

### DIFF
--- a/jsonp/README.md
+++ b/jsonp/README.md
@@ -1,0 +1,21 @@
+# d3.jsonp
+
+Demo: <http://bl.ocks.org/4494715>
+
+A plugin for supporting the [JSONP](http://json-p.org/) technique of requesting
+cross-domain JSON data. This plugin is unstable and in development.
+
+```js
+// autogenerate a callback in the form d3.jsonp.foo
+d3.jsonp('foo.jsonp?callback={callback}', function() {
+  console.log(arguments);
+});
+
+// specify a callback
+d3.jsonp('foo.jsonp?callback=d3.jsonp.foo', function() {
+  console.log(arguments);
+});
+```
+
+This plugin requires servers to accept callbacks with numeric and `.`
+characters. Unlike `d3.xhr` functions, there is no error handling.

--- a/jsonp/jsonp.js
+++ b/jsonp/jsonp.js
@@ -1,0 +1,25 @@
+d3.jsonp = function (url, callback) {
+  function rand() {
+    var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
+      c = '', i = -1;
+    while (++i < 15) c += chars.charAt(Math.floor(Math.random() * 52));
+    return c;
+  }
+
+  function create(url) {
+    var e = url.match(/callback=d3.jsonp.(\w+)/),
+      c = e ? e[1] : rand();
+    d3.jsonp[c] = function(data) {
+      callback(data);
+      delete d3.jsonp[c];
+      script.remove();
+    };
+    return 'd3.jsonp.' + c;
+  }
+
+  var cb = create(url),
+    script = d3.select('head')
+    .append('script')
+    .attr('type', 'text/javascript')
+    .attr('src', url.replace(/(\{|%7B)callback(\{|%7D)/, cb));
+};


### PR DESCRIPTION
Adds a `d3.jsonp` function. There are certain design factors which might need tuning:
- callbacks are named `d3.jsonp.foo` in order to avoid cluttering the `window` variable with their names. but this requires jsonp implementations that support `.`s in callbacks. I think most do.
- there's no strong guarantee that this will not reuse a callback name, though there are 15^52 potentials.
