### PR TITLE
Sankey Plugin, complex path to draw links

### DIFF
--- a/sankey/sankey.js
+++ b/sankey/sankey.js
@@ -59,12 +59,20 @@ d3.sankey = function() {
           xi = d3.interpolateNumber(x0, x1),
           x2 = xi(curvature),
           x3 = xi(1 - curvature),
-          y0 = d.source.y + d.sy + d.dy / 2,
-          y1 = d.target.y + d.ty + d.dy / 2;
+          y0 = d.source.y + d.sy,
+          y1 = d.target.y + d.ty,
+          y2 = y1 + d.dy,
+          y3 = y0 + d.dy;
+
       return "M" + x0 + "," + y0
            + "C" + x2 + "," + y0
            + " " + x3 + "," + y1
-           + " " + x1 + "," + y1;
+           + " " + x1 + "," + y1
+           + " L" + x1 + "," + y2
+           + "C" + x3+ "," + y2
+           + " " + x2 + "," + y3
+           + " " + x0 + "," + y3
+           + "Z";
     }
 
     link.curvature = function(_) {


### PR DESCRIPTION
As seen in
http://bl.ocks.org/d/4599519/

using a thick line to draw links between blocks can lead to artifacts ( just drag the blocks around) 

this patch uses a set of 4 lines to draw the connection between blocks, see
http://bl.ocks.org/d/4599792/

see also
http://bl.ocks.org/d/4590576/
for the usual example after this patch
