### PR TITLE
Undefined local variable: 'radius'

### DIFF
--- a/hexbin/hexbin.js
+++ b/hexbin/hexbin.js
@@ -37,7 +37,7 @@ d3.hexbin = function() {
     return d3.values(binsById);
   }
 
-  function hexagon() {
+  function hexagon(radius) {
     var x0 = 0, y0 = 0;
     return d3_hexbinAngles.map(function(angle) {
       var x1 = Math.sin(angle) * radius,
@@ -63,7 +63,7 @@ d3.hexbin = function() {
 
   hexbin.hexagon = function(radius) {
     if (arguments.length < 1) radius = r;
-    return "m" + hexagon().join("l") + "z";
+    return "m" + hexagon(radius).join("l") + "z";
   };
 
   hexbin.mesh = function() {


### PR DESCRIPTION
Variable 'radius' inside hexagon() is undefined.
Based on changes previous commit it looks like this should be passed into hexagon().
