### PR TITLE
Fixed Eckert IV invert function

### DIFF
--- a/geo/projection/eckert4.js
+++ b/geo/projection/eckert4.js
@@ -15,7 +15,7 @@ function eckert4(λ, φ) {
 
 eckert4.invert = function(x, y) {
   var j = 2 * Math.sqrt(π / (4 + π)),
-      k = asin(y / cy),
+      k = asin((y / 2) * Math.sqrt((4 + π) / π)),
       c = Math.cos(k);
   return [
     x / (2 / Math.sqrt(π * (4 + π)) * (1 + c)),


### PR DESCRIPTION
I'm working on a map project based on D3 (http://worldmapgenerator.com) and we've found a problem with the invert Eckert IV function. I basically get a "cy not defined". I implemented the invert math formula from here to fix this : 

http://mathworld.wolfram.com/EckertIVProjection.html

It's working ok now. We use the invert function to drag the maps and to detect the country clicked. I hope this helps ;)
