### PR TITLE
Sort sankey target links by descending slope.

### DIFF
--- a/sankey/sankey.js
+++ b/sankey/sankey.js
@@ -257,22 +257,31 @@ d3.sankey = function() {
   function computeLinkDepths() {
     nodes.forEach(function(node) {
       node.sourceLinks.sort(ascendingTargetDepth);
-      node.targetLinks.sort(ascendingSourceDepth);
     });
     nodes.forEach(function(node) {
-      var sy = 0, ty = 0;
+      var sy = 0;
       node.sourceLinks.forEach(function(link) {
         link.sy = sy;
         sy += link.dy;
       });
+    });
+    nodes.forEach(function(node) {
+      node.targetLinks.sort(descendingLinkSlope);
+    });
+    nodes.forEach(function(node) {
+      var ty = 0;
       node.targetLinks.forEach(function(link) {
         link.ty = ty;
         ty += link.dy;
       });
     });
 
-    function ascendingSourceDepth(a, b) {
-      return a.source.y - b.source.y;
+    function descendingLinkSlope(a, b) {
+        function slope(l) {
+          return (l.target.y - (l.source.y + l.sy)) /
+              (l.target.x - l.source.x);
+        }
+        return slope(b) - slope(a);
     }
 
     function ascendingTargetDepth(a, b) {


### PR DESCRIPTION
Looking at the Sankey example (http://bost.ocks.org/mike/sankey/), nodes like "Road transport" occur frequently which have crossing link lines. This creates unnecessary visual confusion. The problem occurs when a "higher" node is also farther left in the chart which causes the lines to cross as they reach the target. (Other nodes with the problem include "Electricity grid" and "Industry", although these are both more difficult to see in this particular chart.)

Using the link's slope (as if it were a straight line) as a heuristic, we can reduce the number of crossings at the target end. 

Before:
![screen shot 2013-08-30 at 11 16 21 am](https://f.cloud.github.com/assets/1387245/1058338/2b2a46be-1187-11e3-8434-822b70bc8501.png)

After:
![screen shot 2013-08-30 at 11 17 07 am](https://f.cloud.github.com/assets/1387245/1058345/413e5652-1187-11e3-8505-53455dba3544.png)
