### PR TITLE
horizon plugin: added horizon.colorDomain()

### DIFF
--- a/horizon/horizon.js
+++ b/horizon/horizon.js
@@ -114,14 +114,24 @@
 
     horizon.bands = function(_) {
       if (!arguments.length) return bands;
+      // Get original unscaled color scale domain.
+      domain = color.domain().map(function(d) { return d / bands; });
+      // Update bands and color scale domain.
       bands = +_;
-      color.domain([-bands, 0, bands]);
-      return horizon;
+      color.domain(domain.map(function(d) { return d * bands; }));
     };
 
     horizon.mode = function(_) {
       if (!arguments.length) return mode;
       mode = _ + "";
+      return horizon;
+    };
+
+    horizon.colorDomain = function(_) {
+      if (!arguments.length) return color.domain();
+      // Rescale domain to bands.
+      _ = _.map(function(d) { return d * bands; });
+      color.domain(_);
       return horizon;
     };
 


### PR DESCRIPTION
horizon.colorDomain() complements horizon.colors() and allows to
use more than the default three ([-1, 0, 1]) control points to
define the color range of the bands.
