### PR TITLE
Source link sorting by angle

### DIFF
--- a/sankey/sankey.js
+++ b/sankey/sankey.js
@@ -4,7 +4,8 @@ d3.sankey = function() {
       nodePadding = 8,
       size = [1, 1],
       nodes = [],
-      links = [];
+      links = [],
+      sourceDepthSortWeight = 3;
 
   sankey.nodeWidth = function(_) {
     if (!arguments.length) return nodeWidth;
@@ -272,7 +273,7 @@ d3.sankey = function() {
     });
 
     function ascendingSourceDepth(a, b) {
-      return a.source.y - b.source.y;
+       return -(Math.atan((a.target.y - a.source.y) / Math.pow(a.target.x - a.source.x, sourceDepthSortWeight)) - Math.atan((b.target.y - b.source.y) / Math.pow(b.target.x - b.source.x, sourceDepthSortWeight)));
     }
 
     function ascendingTargetDepth(a, b) {


### PR DESCRIPTION
Incoming source links to a node are sorted by the angle between the
source and target nodes, rather than their difference in y. It produces
cleaner diagrams, and has a customizable weighting factor to give more
weight to the x difference between nodes. The default value of 3 seems
to work well.

Without sorting fix - most obvious at the "Electricity Generation" node:
![olddiagram](https://f.cloud.github.com/assets/7025865/2487601/48090310-b137-11e3-99da-3f6ac278235c.PNG)

With the fix - better sorting at all nodes, especially "Electricity Generation" and "Conversion Losses":
![fixeddiagram](https://f.cloud.github.com/assets/7025865/2487602/4bd9a5a8-b137-11e3-8774-d84b8cd0b7b1.PNG)
