### PR TITLE
Links now rendered properly when taller than they are wide

### DIFF
--- a/sankey/sankey.js
+++ b/sankey/sankey.js
@@ -29,7 +29,7 @@ d3.sankey = function() {
     links = _;
     return sankey;
   };
-
+ 
   sankey.size = function(_) {
     if (!arguments.length) return size;
     size = _;
@@ -59,12 +59,19 @@ d3.sankey = function() {
           xi = d3.interpolateNumber(x0, x1),
           x2 = xi(curvature),
           x3 = xi(1 - curvature),
-          y0 = d.source.y + d.sy + d.dy / 2,
-          y1 = d.target.y + d.ty + d.dy / 2;
-      return "M" + x0 + "," + y0
-           + "C" + x2 + "," + y0
-           + " " + x3 + "," + y1
-           + " " + x1 + "," + y1;
+          y0 = d.source.y + d.sy + d.strokeWidth / 2,
+          y1 = d.target.y + d.ty + d.strokeWidth / 2,
+          path = "";
+
+      for (var i = 0; i < d.countBeziers; i++) {
+          path = path
+              + "M" + x0 + "," + (y0 + d.strokeWidth * i)
+              + "C" + x2 + "," + (y0 + d.strokeWidth * i)
+              + " " + x3 + "," + (y1 + d.strokeWidth * i)
+              + " " + x1 + "," + (y1 + d.strokeWidth * i);
+      }
+
+      return path;
     }
 
     link.curvature = function(_) {
@@ -182,7 +189,10 @@ d3.sankey = function() {
       });
 
       links.forEach(function(link) {
+        link.dx = link.target.x - (link.source.x + link.source.dx);
         link.dy = link.value * ky;
+        link.countBeziers = Math.ceil(size[1] / link.dx);
+        link.strokeWidth = link.dy / link.countBeziers;
       });
     }
 


### PR DESCRIPTION
Each link between nodes is drawn using a bezier curve from the right-hand side of the From node to the left-hand side of the To node.  The stroke width of the bezier curve corresponds to the amount of flow.

If a bezier curve has a wide stroke width and slopes up or down steeply, it sweeps out too much area.  Here's a picture of the problem: http://s27.postimg.org/ifhkwvddv/render_problem.png

I fixed the problem by placing a maximum on the widths of the Bezier curves.  Large links are now drawn using several smaller adjacent bezier curves.

This is a breaking change in some cases: existing code setting each path's stroke width to the link's `dy` property should now use the link's `strokeWidth` property.
