### PR TITLE
Fix memory usage issue caused by adding same node multiple times

### DIFF
--- a/sankey/sankey.js
+++ b/sankey/sankey.js
@@ -117,8 +117,10 @@ d3.sankey = function() {
       remainingNodes.forEach(function(node) {
         node.x = x;
         node.dx = nodeWidth;
-        node.sourceLinks.forEach(function(link) {
-          nextNodes.push(link.target);
+        node.sourceLinks.forEach(function (link) {
+          if (nextNodes.indexOf(link.target) == -1) {
+            nextNodes.push(link.target);
+          }
         });
       });
       remainingNodes = nextNodes;


### PR DESCRIPTION
This issue happens when multiple nodes share same target node, and will consume lots of memory and slow down the layout calculation greatly when a graph being rendered is close to a complete bipartite graph at each step of the flow.

I'm using this Sankey library and seeing it causes browser out-of-memory quite often with the issue. After applied this fix, rendering completes all the time without the memory issue and becomes faster.
