### PR TITLE
sankey: fix nodesByBreadth to have proper ordering

### DIFF
--- a/sankey/sankey.js
+++ b/sankey/sankey.js
@@ -157,7 +157,7 @@ d3.sankey = function() {
   function computeNodeDepths(iterations) {
     var nodesByBreadth = d3.nest()
         .key(function(d) { return d.x; })
-        .sortKeys(d3.ascending)
+        .sortKeys(function(a, b) { return a - b; })
         .entries(nodes)
         .map(function(d) { return d.values; });
 


### PR DESCRIPTION
d3.nest().key() converts all keys into strings. d3.ascending does not coerce strings into numbers for comparison -- do it ourselves.

This improves relaxation efficiency. Before, it could traverse levels in the wrong order, taking longer to propagate values up.