### PR TITLE
Fixed multiple lasso bug

### DIFF
--- a/lasso/lasso.js
+++ b/lasso/lasso.js
@@ -106,7 +106,7 @@ d3.lasso = function() {
 			isPathClosed = distance<=closePathDistance;
 
 	  		// create complete path
-	  		var complete_path_d = d3.select("path")[0][0].attributes.d.value + "Z";
+	  		var complete_path_d = path + "Z";
 	  		complete_path.attr("d",complete_path_d);
 
 			// get path length


### PR DESCRIPTION
A d3.select("path") is called to select the path drawn in order to get the path definition and create a closed path from it. This does not work if multiple lassos are drawn on the page, since the d3.select("path") will only select the first path. Instead of using d3.select() to find this value, it is actually already stored previously in a variable called "path". So the closed path can be created by just using 
path + "Z";

Instead of d3.select(path). This version allows you to use multiple lasso's on one page.