### PR TITLE
Fix circular fisheye error in case delta x and delta y are both 0

### DIFF
--- a/fisheye/fisheye.js
+++ b/fisheye/fisheye.js
@@ -11,10 +11,14 @@
           focus = [0, 0];
 
       function fisheye(d) {
+        if(d.x === focus[0] && d.y === focus[1]) {
+          focus[ 0 ] -= 0.00001;
+          focus[ 1 ] -= 0.00001;
+        }
         var dx = d.x - focus[0],
             dy = d.y - focus[1],
             dd = Math.sqrt(dx * dx + dy * dy);
-        if (!dd || dd >= radius) return {x: d.x, y: d.y, z: 1};
+        if (dd >= radius) return {x: d.x, y: d.y, z: 1};
         var k = k0 * (1 - Math.exp(-dd * k1)) / dd * .75 + .25;
         return {x: focus[0] + dx * k, y: focus[1] + dy * k, z: Math.min(k, 10)};
       }
@@ -83,3 +87,4 @@
     return d3.rebind(fisheye, scale, "domain", "range");
   }
 })();
+


### PR DESCRIPTION
when data.x === focus[0] and data.y === focus[1], dx and dy become zero. Once this happens, fisheye behaves as if the data node is not influenced by the focus point at all, which is faulty behaviour.

For example, suppose you are using your mouse pointer as the focus point and fisheye should influence the center of an svg circle: Once you manage to position your mouse pointer exactly at the center of the circle, fisheye will completely stop influencing the circle

To prevent dx and dy becoming both zero, a tiny offset is added to focus[0] and focus[1]