### PR TITLE
Expose d3-plugin-sankey from node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "d3-plugins",
+    "version": "0.1.0",
+
+    "peerDependencies": {
+        "d3": "^3.5.0"
+    },
+
+    "main": "pluginloader.js"
+}

--- a/pluginloader.js
+++ b/pluginloader.js
@@ -1,0 +1,39 @@
+
+;(function() {
+  /* jshint node:true, asi:true, eqnull:true */
+  "use strict";
+  var has_require = typeof require !== 'undefined';
+
+  var d3 = this.d3;
+  if( typeof d3 === 'undefined' ) {
+    if( has_require ) {
+      d3 = require('d3');
+    }
+    else throw new Error('d3 plugins require d3');
+  }
+
+  var pluginloader = function(obj) {
+    if (obj instanceof pluginloader) {
+      return obj;
+    }
+    if (!(this instanceof pluginloader)) {
+      return new pluginloader(obj);
+    }
+    this._wrapped = obj;
+  };
+
+  if( typeof exports !== 'undefined' ) {
+    if( typeof module !== 'undefined' && module.exports ) {
+      exports = module.exports = pluginloader;
+    } else {
+      exports.pluginloader = pluginloader;
+    }
+  }
+
+  pluginloader.load = function(pluginname) {
+    if ( has_require ) {
+      require('./' + pluginname + '/' + pluginname);
+    }
+  }
+
+}).call(this);

--- a/sankey/sankey.js
+++ b/sankey/sankey.js
@@ -1,3 +1,15 @@
+
+;(function() {
+var has_require = typeof require !== 'undefined';
+
+  var d3 = this.d3;
+if( typeof d3 === 'undefined' ) {
+  if( has_require ) {
+    d3 = require('d3');
+  }
+  else throw new Error('d3 plugins require d3');
+}
+
 d3.sankey = function() {
   var sankey = {},
       nodeWidth = 24,
@@ -292,3 +304,4 @@ d3.sankey = function() {
 
   return sankey;
 };
+}).call(this);


### PR DESCRIPTION
Although d3 itself exists as a node.js package, the plugins are usable
only from the browser.

--Make sure sankey plugin can be loaded through node.js
--Put in basic package structure and plugin loadin mechanism for node