### PR TITLE
geo.tile zoomMax option to limit zoom level

### DIFF
--- a/geo/tile/tile.js
+++ b/geo/tile/tile.js
@@ -2,11 +2,13 @@ d3.geo.tile = function() {
   var size = [960, 500],
       scale = 256,
       translate = [size[0] / 2, size[1] / 2],
-      zoomDelta = 0;
+      zoomDelta = 0,
+      zoomMax = null;
 
   function tile() {
     var z = Math.max(Math.log(scale) / Math.LN2 - 8, 0),
-        z0 = Math.round(z + zoomDelta),
+        zDelta = (z + zoomDelta),
+        z0 = (zoomMax && (zDelta > zoomMax)) ? zoomMax : Math.round(zDelta),
         k = Math.pow(2, z - z0 + 8),
         origin = [(translate[0] - scale / 2) / k, (translate[1] - scale / 2) / k],
         tiles = [],
@@ -46,6 +48,12 @@ d3.geo.tile = function() {
   tile.zoomDelta = function(_) {
     if (!arguments.length) return zoomDelta;
     zoomDelta = +_;
+    return tile;
+  };
+
+  tile.zoomMax = function(_) {
+    if (!arguments.length) return zoomMax;
+    zoomMax = +_;
     return tile;
   };
 


### PR DESCRIPTION
Limiting the max zoom level allows vectile maps unlimited zoom (at a certain detail level). 

Solves #134